### PR TITLE
Fix `no-useless-constructors` rule for TypeScript

### DIFF
--- a/eslint-config/typescript.js
+++ b/eslint-config/typescript.js
@@ -23,6 +23,9 @@ export default [
       '@typescript-eslint/no-use-before-define':
         ['error', {functions: false, ignoreTypeReferences: true}],
 
+      'no-useless-constructor': 'off',
+      '@typescript-eslint/no-useless-constructor': 'error',
+
       // Rules turned off for now
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/reviewable-configs/7)
<!-- Reviewable:end -->
