### PR TITLE
Fix `no-useless-function` for TypeScript

### DIFF
--- a/eslint-config/typescript.js
+++ b/eslint-config/typescript.js
@@ -26,6 +26,9 @@ export default [
       'no-useless-constructor': 'off',
       '@typescript-eslint/no-useless-constructor': 'error',
 
+      'no-useless-function': 'off',
+      '@typescript-eslint/no-useless-function': 'error',
+
       // Rules turned off for now
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/reviewable-configs/8)
<!-- Reviewable:end -->
