### PR TITLE
Add `reviewable-upgrade` wrapper around `yarn up`.

### DIFF
--- a/bin/reviewable-upgrade.mjs
+++ b/bin/reviewable-upgrade.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+// Workaround for https://github.com/yarnpkg/berry/issues/1492
+
+import {runUpgrade} from '../lib/reviewable-upgrade.js';
+
+process.exit(runUpgrade());

--- a/lib/reviewable-upgrade.js
+++ b/lib/reviewable-upgrade.js
@@ -1,0 +1,114 @@
+import {spawnSync} from 'child_process';
+import {existsSync, readFileSync} from 'fs';
+import path from 'path';
+
+const MANIFEST_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies'];
+
+export function findNearestPackageJson(startDir = process.cwd()) {
+  let currentDir = path.resolve(startDir);
+  while (true) {
+    const manifestPath = path.join(currentDir, 'package.json');
+    if (existsSync(manifestPath)) return manifestPath;
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) return null;
+    currentDir = parentDir;
+  }
+}
+
+export function splitDescriptor(descriptor) {
+  if (descriptor.startsWith('@')) {
+    const slashIndex = descriptor.indexOf('/');
+    if (slashIndex === -1) return {ident: descriptor, range: null};
+
+    const rangeIndex = descriptor.indexOf('@', slashIndex + 1);
+    if (rangeIndex === -1) return {ident: descriptor, range: null};
+
+    return {
+      ident: descriptor.slice(0, rangeIndex),
+      range: descriptor.slice(rangeIndex + 1)
+    };
+  }
+
+  const rangeIndex = descriptor.indexOf('@');
+  if (rangeIndex === -1) return {ident: descriptor, range: null};
+
+  return {
+    ident: descriptor.slice(0, rangeIndex),
+    range: descriptor.slice(rangeIndex + 1)
+  };
+}
+
+export function normalizeGitHubRange(range) {
+  if (typeof range !== 'string') return null;
+  if (range.startsWith('github:')) return range;
+
+  const shorthandMatch = range.match(
+    /^(?<repo>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?<fragment>#.+)?$/
+  );
+  if (shorthandMatch) {
+    return `github:${shorthandMatch.groups.repo}${shorthandMatch.groups.fragment ?? ''}`;
+  }
+
+  const githubUrlMatch = range.match(
+    /^(?:git\+)?https:\/\/github\.com\/(?<repo>[^/#]+\/[^/#]+?)(?:\.git)?(?<fragment>#.+)?$/i
+  );
+  if (githubUrlMatch) {
+    return `github:${githubUrlMatch.groups.repo}${githubUrlMatch.groups.fragment ?? ''}`;
+  }
+
+  const githubSshMatch = range.match(
+    /^(?:git\+)?ssh:\/\/git@github\.com\/(?<repo>[^/#]+\/[^/#]+?)(?:\.git)?(?<fragment>#.+)?$/i
+  ) ?? range.match(
+    /^git@github\.com:(?<repo>[^/#]+\/[^/#]+?)(?:\.git)?(?<fragment>#.+)?$/i
+  );
+  if (githubSshMatch) {
+    return `github:${githubSshMatch.groups.repo}${githubSshMatch.groups.fragment ?? ''}`;
+  }
+
+  return null;
+}
+
+export function rewriteUpgradeArgs(packageJson, args) {
+  const dependencyRanges = new Map();
+  for (const field of MANIFEST_FIELDS) {
+    for (const [name, range] of Object.entries(packageJson[field] ?? {})) {
+      dependencyRanges.set(name, range);
+    }
+  }
+
+  return args.map(arg => {
+    if (arg.startsWith('-')) return arg;
+
+    const {ident, range} = splitDescriptor(arg);
+    if (!ident || range !== null || ident.includes('*')) return arg;
+
+    const normalizedRange = normalizeGitHubRange(dependencyRanges.get(ident));
+    return normalizedRange ? `${ident}@${normalizedRange}` : arg;
+  });
+}
+
+export function runUpgrade({argv = process.argv.slice(2), cwd = process.cwd()} = {}) {
+  const manifestPath = findNearestPackageJson(cwd);
+  if (!manifestPath) {
+    console.error('reviewable-upgrade: Could not find a package.json in the current directory tree.');
+    return 1;
+  }
+
+  const manifestDir = path.dirname(manifestPath);
+  const packageJson = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const rewrittenArgs = rewriteUpgradeArgs(packageJson, argv);
+
+  const result = spawnSync('yarn', ['up', ...rewrittenArgs], {
+    cwd: manifestDir,
+    shell: process.platform === 'win32',
+    stdio: 'inherit'
+  });
+
+  if (result.error) {
+    console.error(`reviewable-upgrade: ${result.error.message}`);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "license": "MIT",
   "type": "module",
   "packageManager": "yarn@4.13.0",
+  "bin": {
+    "reviewable-upgrade": "./bin/reviewable-upgrade.mjs"
+  },
+  "scripts": {
+    "test": "node --test --test-isolation=none test/reviewable-upgrade.test.js"
+  },
   "dependencies": {
     "eslint": "^8.57.0 || ^9.12.0",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/test/reviewable-upgrade.test.js
+++ b/test/reviewable-upgrade.test.js
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  findNearestPackageJson,
+  normalizeGitHubRange,
+  rewriteUpgradeArgs,
+  splitDescriptor
+} from '../lib/reviewable-upgrade.js';
+
+test('splitDescriptor handles unscoped and scoped descriptors', () => {
+  assert.deepEqual(splitDescriptor('lodash'), {ident: 'lodash', range: null});
+  assert.deepEqual(splitDescriptor('lodash@1.2.3'), {ident: 'lodash', range: '1.2.3'});
+  assert.deepEqual(splitDescriptor('@types/node'), {ident: '@types/node', range: null});
+  assert.deepEqual(splitDescriptor('@types/node@20.12.7'), {ident: '@types/node', range: '20.12.7'});
+});
+
+test('normalizeGitHubRange handles shorthand, github protocol, and github urls', () => {
+  assert.equal(
+    normalizeGitHubRange('Reviewable/reviewable-configs'),
+    'github:Reviewable/reviewable-configs'
+  );
+  assert.equal(
+    normalizeGitHubRange('reviewable/sentencesimilarity#master'),
+    'github:reviewable/sentencesimilarity#master'
+  );
+  assert.equal(
+    normalizeGitHubRange('github:Reviewable/diff-objects#master'),
+    'github:Reviewable/diff-objects#master'
+  );
+  assert.equal(
+    normalizeGitHubRange('https://github.com/Reviewable/reviewable-configs.git#main'),
+    'github:Reviewable/reviewable-configs#main'
+  );
+  assert.equal(
+    normalizeGitHubRange('git@github.com:Reviewable/reviewable-configs.git#main'),
+    'github:Reviewable/reviewable-configs#main'
+  );
+  assert.equal(normalizeGitHubRange('file:../reviewable-configs'), null);
+});
+
+test('rewriteUpgradeArgs rewrites github-backed dependencies and preserves other args', () => {
+  const packageJson = {
+    dependencies: {
+      'diff-objects': 'Reviewable/diff-objects#master',
+      lodash: '^4.17.21'
+    },
+    devDependencies: {
+      'reviewable-configs': 'github:Reviewable/reviewable-configs',
+      '@types/node': '^20.12.7'
+    },
+    optionalDependencies: {
+      jquery: 'reviewable/jquery#2.1.3-custom'
+    }
+  };
+
+  assert.deepEqual(
+    rewriteUpgradeArgs(packageJson, [
+      'reviewable-configs',
+      'diff-objects',
+      'lodash',
+      '@types/node',
+      'jquery',
+      '@babel/*',
+      'reviewable-configs@github:Reviewable/reviewable-configs',
+      '--mode=update-lockfile',
+      '-i'
+    ]),
+    [
+      'reviewable-configs@github:Reviewable/reviewable-configs',
+      'diff-objects@github:Reviewable/diff-objects#master',
+      'lodash',
+      '@types/node',
+      'jquery@github:reviewable/jquery#2.1.3-custom',
+      '@babel/*',
+      'reviewable-configs@github:Reviewable/reviewable-configs',
+      '--mode=update-lockfile',
+      '-i'
+    ]
+  );
+});
+
+test('findNearestPackageJson walks up the directory tree', () => {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'reviewable-upgrade-'));
+  try {
+    writeFileSync(path.join(tempRoot, 'package.json'), '{"name":"root"}');
+    const nestedDir = path.join(tempRoot, 'a', 'b', 'c');
+    mkdirSync(nestedDir, {recursive: true});
+
+    assert.equal(findNearestPackageJson(nestedDir), path.join(tempRoot, 'package.json'));
+  } finally {
+    rmSync(tempRoot, {recursive: true, force: true});
+  }
+});
+
+test('findNearestPackageJson returns null when no manifest exists', () => {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'reviewable-upgrade-empty-'));
+  try {
+    const nestedDir = path.join(tempRoot, 'a', 'b');
+    mkdirSync(nestedDir, {recursive: true});
+
+    assert.equal(findNearestPackageJson(nestedDir), null);
+  } finally {
+    rmSync(tempRoot, {recursive: true, force: true});
+  }
+});


### PR DESCRIPTION
`yarn up pkg` fails when invoked for a dependency that directly targets a GitHub repo (see https://github.com/yarnpkg/berry/issues/1492).  This PR adds a script that works around the issue by rewriting any such "direct" dependencies into the right form for Yarn.

Oddly `yarn up` (with no arguments) works fine on these, so not sure why the targeted upgrade is broken.

This script is meant to be invoked as `yarn upgrade` in our repos.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/reviewable-configs/12)
<!-- Reviewable:end -->
